### PR TITLE
feat(nav): expand top-level menu with Get Started, Guide, Advanced

### DIFF
--- a/pages/en/_meta.ts
+++ b/pages/en/_meta.ts
@@ -4,12 +4,85 @@ export default {
     type: "page",
     display: "hidden",
     theme: {
-      layout: "raw"
-    }
+      layout: "raw",
+    },
   },
   docs: {
     type: "page",
-    title: "Documentation"
+    title: "Documentation",
+  },
+  start: {
+    type: "page",
+    title: "Get Started",
+    href: "/en/docs/start",
+  },
+  guide: {
+    type: "menu",
+    title: "Guide",
+    items: {
+      "user-guide": {
+        title: "User Guide",
+        href: "/en/docs/guide",
+      },
+      loader: {
+        title: "Loader",
+        href: "/en/docs/guide/loader",
+      },
+      client: {
+        title: "Client",
+        href: "/en/docs/guide/client",
+      },
+      server: {
+        title: "Server",
+        href: "/en/docs/guide/server",
+      },
+      "async-stream": {
+        title: "Async Stream",
+        href: "/en/docs/guide/async-stream",
+      },
+      credentials: {
+        title: "Credentials",
+        href: "/en/docs/guide/credentials",
+      },
+      metadata: {
+        title: "Metadata",
+        href: "/en/docs/guide/metadata",
+      },
+      status: {
+        title: "Status",
+        href: "/en/docs/guide/status",
+      },
+      config: {
+        title: "Config",
+        href: "/en/docs/guide/config",
+      },
+    },
+  },
+  advanced: {
+    type: "menu",
+    title: "Advanced",
+    items: {
+      overview: {
+        title: "Overview",
+        href: "/en/docs/advanced",
+      },
+      "client-middleware": {
+        title: "Client Middleware",
+        href: "/en/docs/advanced/client-middleware",
+      },
+      "server-middleware": {
+        title: "Server Middleware",
+        href: "/en/docs/advanced/server-middleware",
+      },
+      "grpc-reflection": {
+        title: "gRPC Reflection",
+        href: "/en/docs/advanced/grpc-reflection",
+      },
+      "handle-proto": {
+        title: "Handle Proto",
+        href: "/en/docs/advanced/handle-proto",
+      },
+    },
   },
   apis: {
     title: "API",
@@ -17,16 +90,16 @@ export default {
     items: {
       "proto-loader": {
         title: "Proto Loader",
-        href: "/en/docs/apis/proto-loader"
+        href: "/en/docs/apis/proto-loader",
       },
       "client-side": {
         title: "Client Side",
-        href: "/en/docs/apis/client-side"
+        href: "/en/docs/apis/client-side",
       },
       "server-side": {
         title: "Server Side",
-        href: "/en/docs/apis/server-side"
-      }
-    }
-  }
-}
+        href: "/en/docs/apis/server-side",
+      },
+    },
+  },
+};

--- a/pages/zh/_meta.ts
+++ b/pages/zh/_meta.ts
@@ -4,12 +4,85 @@ export default {
     type: "page",
     display: "hidden",
     theme: {
-      layout: "raw"
-    }
+      layout: "raw",
+    },
   },
   docs: {
     type: "page",
-    title: "文档"
+    title: "文档",
+  },
+  start: {
+    type: "page",
+    title: "快速上手",
+    href: "/zh/docs/start",
+  },
+  guide: {
+    type: "menu",
+    title: "指南",
+    items: {
+      "user-guide": {
+        title: "使用指南",
+        href: "/zh/docs/guide",
+      },
+      loader: {
+        title: "Loader",
+        href: "/zh/docs/guide/loader",
+      },
+      client: {
+        title: "Client",
+        href: "/zh/docs/guide/client",
+      },
+      server: {
+        title: "Server",
+        href: "/zh/docs/guide/server",
+      },
+      "async-stream": {
+        title: "Async Stream",
+        href: "/zh/docs/guide/async-stream",
+      },
+      credentials: {
+        title: "Credentials",
+        href: "/zh/docs/guide/credentials",
+      },
+      metadata: {
+        title: "Metadata",
+        href: "/zh/docs/guide/metadata",
+      },
+      status: {
+        title: "Status",
+        href: "/zh/docs/guide/status",
+      },
+      config: {
+        title: "Config",
+        href: "/zh/docs/guide/config",
+      },
+    },
+  },
+  advanced: {
+    type: "menu",
+    title: "高级",
+    items: {
+      overview: {
+        title: "概览",
+        href: "/zh/docs/advanced",
+      },
+      "client-middleware": {
+        title: "Client Middleware",
+        href: "/zh/docs/advanced/client-middleware",
+      },
+      "server-middleware": {
+        title: "Server Middleware",
+        href: "/zh/docs/advanced/server-middleware",
+      },
+      "grpc-reflection": {
+        title: "gRPC Reflection",
+        href: "/zh/docs/advanced/grpc-reflection",
+      },
+      "handle-proto": {
+        title: "Handle Proto",
+        href: "/zh/docs/advanced/handle-proto",
+      },
+    },
   },
   apis: {
     title: "API",
@@ -17,16 +90,16 @@ export default {
     items: {
       "proto-loader": {
         title: "Proto Loader",
-        href: "/zh/docs/apis/proto-loader"
+        href: "/zh/docs/apis/proto-loader",
       },
       "client-side": {
         title: "Client Side",
-        href: "/zh/docs/apis/client-side"
+        href: "/zh/docs/apis/client-side",
       },
       "server-side": {
         title: "Server Side",
-        href: "/zh/docs/apis/server-side"
-      }
-    }
-  }
-}
+        href: "/zh/docs/apis/server-side",
+      },
+    },
+  },
+};


### PR DESCRIPTION
Promote Get Started, Guide and Advanced from sidebar entries to top-level navbar items so the most-used sections are reachable in one click. Guide and Advanced render as dropdowns with the same items that appear in the sidebar. Locale-synced for /en and /zh.